### PR TITLE
Refactor Affine3d -> Isometry3d (Melodic)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosparam_shortcuts)
 
-# C++ 11
-add_compile_options(-std=c++11)
+# C++ 14
+add_compile_options(-std=c++14)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features:
  - Great for having each class have its own parameter namespace
  - Helpful error messages if parameter is missing, explaining where it expects to find it
  - Removes lots of repetitious code
- - Supports datatypes that rosparam does not by default, such as std::size_t, ros::Duration, Eigen::Affine3d
+ - Supports datatypes that rosparam does not by default, such as std::size_t, ros::Duration, Eigen::Isometry3d, Eigen::Affine3d (deprecated)
  - Supports loading std::vectors easily, and debugging that data
  - Supports loading an entire list of bool parameters
 
@@ -54,7 +54,7 @@ example:
   param1: 20 # int
   param2: 30 # size_t
   param3: 1 # ros::Duration
-  param4: [1, 1, 1, 3.14, 0, 0] # Eigen::Affine3d - x, y, z, roll, pitch, yaw
+  param4: [1, 1, 1, 3.14, 0, 0] # Eigen::Isometry3d - x, y, z, roll, pitch, yaw
   param5: [1.1, 2.2, 3.3, 4.4] # std::vector<double>
 ```
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -3,6 +3,6 @@ example:
   param1: 20 # int
   param2: 30 # size_t
   param3: 1 # ros::Duration
-  param4: [1, 1, 1, 3.14, 0, 0] # Eigen::Affine3d - x, y, z, roll, pitch, yaw
+  param4: [1, 1, 1, 3.14, 0, 0] # Eigen::Isometry3d - x, y, z, roll, pitch, yaw
   param5: [1.1, 2.2, 3.3, 4.4]  # std::vector<double>
-  param6: [2, 2, 2, 1, 0, 0, 0] # Eigen::Affine3d - x, y, z, qw, qz, qy, qz
+  param6: [2, 2, 2, 1, 0, 0, 0] # Eigen::Isometry3d - x, y, z, qw, qz, qy, qz

--- a/include/rosparam_shortcuts/rosparam_shortcuts.h
+++ b/include/rosparam_shortcuts/rosparam_shortcuts.h
@@ -91,7 +91,7 @@ bool get(const std::string &parent_name, const ros::NodeHandle &nh, const std::s
          ros::Duration &value);
 
 bool get(const std::string &parent_name, const ros::NodeHandle &nh, const std::string &param_name,
-         Eigen::Affine3d &value);
+         Eigen::Isometry3d &value);
 
 /**
  * \brief Output a string of values from an array for debugging
@@ -106,7 +106,7 @@ std::string getDebugArrayString(std::vector<std::string> values);
  * \brief Convert from 6 doubles of [x,y,z] [r,p,y] or 7 doubles of [x, y, z, qw, qx, qy, qz] to a transform
  * \return true on success
  */
-bool convertDoublesToEigen(const std::string &parent_name, std::vector<double> values, Eigen::Affine3d &transform);
+bool convertDoublesToEigen(const std::string &parent_name, std::vector<double> values, Eigen::Isometry3d &transform);
 
 /**
  * \brief Check that there were no errors, and if there were, shutdown
@@ -114,6 +114,62 @@ bool convertDoublesToEigen(const std::string &parent_name, std::vector<double> v
  */
 void shutdownIfError(const std::string &parent_name, std::size_t error_count);
 
+// Deprecated support for Affine3d transforms in functions get() and convertDoublesToEigen()
+[[deprecated("Affine3d transforms are deprecated since melodic, use Isometry3d instead.")]]
+bool convertDoublesToEigen(const std::string &parent_name, std::vector<double> values, Eigen::Affine3d &transform)
+{
+  if (values.size() == 6)
+  {
+    // This version is correct RPY
+    Eigen::AngleAxisd roll_angle(values[3], Eigen::Vector3d::UnitX());
+    Eigen::AngleAxisd pitch_angle(values[4], Eigen::Vector3d::UnitY());
+    Eigen::AngleAxisd yaw_angle(values[5], Eigen::Vector3d::UnitZ());
+    Eigen::Quaternion<double> quaternion = roll_angle * pitch_angle * yaw_angle;
+
+    transform = Eigen::Translation3d(values[0], values[1], values[2]) * quaternion;
+
+    return true;
+  }
+  else if (values.size() == 7)
+  {
+    // Quaternion
+    transform = Eigen::Translation3d(values[0], values[1], values[2]) *
+                Eigen::Quaterniond(values[3], values[4], values[5], values[6]);
+    return true;
+  }
+  else
+  {
+    ROS_ERROR_STREAM_NAMED(parent_name, "Invalid number of doubles provided for transform, size=" << values.size());
+    return false;
+  }
+}
+[[deprecated("Affine3d transforms are deprecated since melodic, use Isometry3d instead.")]]
+bool get(const std::string &parent_name, const ros::NodeHandle &nh, const std::string &param_name,
+         Eigen::Affine3d &value)
+{
+  std::vector<double> values;
+
+  // Load a param
+  if (!nh.hasParam(param_name))
+  {
+    ROS_ERROR_STREAM_NAMED(parent_name, "Missing parameter '" << nh.getNamespace() << "/" << param_name << "'.");
+    return false;
+  }
+  nh.getParam(param_name, values);
+
+  if (values.empty())
+    ROS_WARN_STREAM_NAMED(parent_name, "Empty vector for parameter '" << nh.getNamespace() << "/" << param_name << "'"
+                                                                                                                   ".");
+
+  ROS_DEBUG_STREAM_NAMED(parent_name, "Loaded parameter '" << nh.getNamespace() << "/" << param_name
+                                                           << "' with values [" << getDebugArrayString(values) << "]");
+
+  // Convert to Eigen::Affine3d
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"  // suppress warning for deprecated function call
+  convertDoublesToEigen(parent_name, values, value);
+
+  return true;
+}
 }  // namespace rosparam_shortcuts
 
 #endif  // ROSPARAM_SHORTCUTS_ROSPARAM_SHORTCUTS_H

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -61,9 +61,9 @@ int main(int argc, char** argv)
   int param1;
   std::size_t param2;
   ros::Duration param3;
-  Eigen::Affine3d param4;
+  Eigen::Isometry3d param4;
   std::vector<double> param5;
-  Eigen::Affine3d param6;
+  Eigen::Isometry3d param6;
 
   // Load rosparams
   ros::NodeHandle rpnh(nh, name);
@@ -72,9 +72,9 @@ int main(int argc, char** argv)
   error += !rosparam_shortcuts::get(name, rpnh, "param1", param1);              // Int param
   error += !rosparam_shortcuts::get(name, rpnh, "param2", param2);              // SizeT param
   error += !rosparam_shortcuts::get(name, rpnh, "param3", param3);              // Duration param
-  error += !rosparam_shortcuts::get(name, rpnh, "param4", param4);              // Affine3d param
+  error += !rosparam_shortcuts::get(name, rpnh, "param4", param4);              // Isometry3d param
   error += !rosparam_shortcuts::get(name, rpnh, "param5", param5);              // std::vector<double>
-  error += !rosparam_shortcuts::get(name, rpnh, "param6", param6);              // Affine3d param
+  error += !rosparam_shortcuts::get(name, rpnh, "param6", param6);              // Isometry3d param
   // add more parameters here to load if desired
   rosparam_shortcuts::shutdownIfError(name, error);
 

--- a/src/rosparam_shortcuts.cpp
+++ b/src/rosparam_shortcuts.cpp
@@ -208,7 +208,7 @@ bool get(const std::string &parent_name, const ros::NodeHandle &nh, const std::s
 }
 
 bool get(const std::string &parent_name, const ros::NodeHandle &nh, const std::string &param_name,
-         Eigen::Affine3d &value)
+         Eigen::Isometry3d &value)
 {
   std::vector<double> values;
 
@@ -227,7 +227,7 @@ bool get(const std::string &parent_name, const ros::NodeHandle &nh, const std::s
   ROS_DEBUG_STREAM_NAMED(parent_name, "Loaded parameter '" << nh.getNamespace() << "/" << param_name
                                                            << "' with values [" << getDebugArrayString(values) << "]");
 
-  // Convert to Eigen::Affine3d
+  // Convert to Eigen::Isometry3d
   convertDoublesToEigen(parent_name, values, value);
 
   return true;
@@ -253,7 +253,7 @@ std::string getDebugArrayString(std::vector<std::string> values)
   return debug_values.str();
 }
 
-bool convertDoublesToEigen(const std::string &parent_name, std::vector<double> values, Eigen::Affine3d &transform)
+bool convertDoublesToEigen(const std::string &parent_name, std::vector<double> values, Eigen::Isometry3d &transform)
 {
   if (values.size() == 6)
   {


### PR DESCRIPTION
This PR changes all references to the in melodic obsolete type `Eigen::Affine3d` to `Eigen::Isometry3d`.
(required for the melodic-devel branch of [moveit_grasps](https://github.com/ros-planning/moveit_grasps/tree/melodic-devel))