### PR TITLE
Switch run_depend to eigen_conversions.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
   <build_depend>roslint</build_depend>
 
   <run_depend>roscpp</run_depend>
-  <run_depend>eigen</run_depend>
+  <run_depend>eigen_conversions</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
Eigen is header-only (so no run_depend needed), but eigen_conversions
has a library that needs to be pulled in at runtime.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I think this will fix the build errors on the buildfarm: http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ros_control_boilerplate__ubuntu_bionic_amd64__binary/8/consoleFull