### PR TITLE
bump cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosparam_shortcuts)
 
 # C++ 14


### PR DESCRIPTION
get rid of CMP0048 warning.
https://github.com/ros-planning/geometric_shapes/pull/129