### PR TITLE
[ROS-O] drop old C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(rosparam_shortcuts)
 
-# C++ 14
-add_compile_options(-std=c++14)
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   cmake_modules


### PR DESCRIPTION
Regular ROS-O patch as in countless other places.
C++14 is the default in noetic target platforms.